### PR TITLE
Update beta gateway to 0.6.2-rc9 to fix ABRP integration

### DIFF
--- a/saic-python-mqtt-gateway-pre/config.yaml
+++ b/saic-python-mqtt-gateway-pre/config.yaml
@@ -8,7 +8,7 @@ image: "saicismartapi/saic-python-mqtt-gateway"
 url: "https://github.com/SAIC-iSmart-API/saic-home-assistant-addon"
 slug: "saic_python_mqtt_gateway-pre"
 stage: "experimental"
-version: "0.6.2-rc8"
+version: "0.6.2-rc9"
 legacy: true
 map: 
   - config:rw


### PR DESCRIPTION
Fixes an uncaught exception in the ABRP code when the car decides not supply us with an estimated range